### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/stability/ParseTable.py
+++ b/stability/ParseTable.py
@@ -71,7 +71,7 @@ def read_regions_from_table(path = "",tableFile= "",xVar=""):
                 if region.split('-runNumber')[0] not in regions:
                     regions.append(region.split('-runNumber')[0])
             else:
-                part = re.findall('[%s]+' % string.ascii_letters,region.replace(xVar,''))
+                part = re.findall('[{0!s}]+'.format(string.ascii_letters),region.replace(xVar,''))
                 if len(part) == 0:
                     part = 'inclusive'
                     if part not in regions:

--- a/stability/ParseVariable.py
+++ b/stability/ParseVariable.py
@@ -62,11 +62,11 @@ def bias_peak_monitor(xbin, hist, x, spl, label='', args = {}):
             horizontalalignment='right',
             verticalalignment='top',
             transform=ax1.transAxes,fontsize=7)
-    ax1.text(0.95,0.90,'peak = %1.2f GeV'% (peaks[0]),
+    ax1.text(0.95,0.90,'peak = {0:1.2f} GeV'.format((peaks[0])),
             horizontalalignment='right',
             verticalalignment='top',
             transform=ax1.transAxes,fontsize=7)
-    ax1.text(0.95,0.85,'FWHM = %1.2f GeV'% (max(roots)-min(roots)),
+    ax1.text(0.95,0.85,'FWHM = {0:1.2f} GeV'.format((max(roots)-min(roots))),
             horizontalalignment='right',
             verticalalignment='top',
             transform=ax1.transAxes,fontsize=7)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:yhaddad:ECALValidation?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:yhaddad:ECALValidation?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
